### PR TITLE
Add canonical definitions and aliases

### DIFF
--- a/lib/data/tzdb/tzdb.json
+++ b/lib/data/tzdb/tzdb.json
@@ -422,5 +422,18 @@
   "Indian/Mayotte": "indian_mayotte",
   "Africa/Johannesburg": "africa_johannesburg",
   "Africa/Lusaka": "africa_lusaka",
-  "Africa/Harare": "africa_harare"
+  "Africa/Harare": "africa_harare",
+  "CET": "europe_paris",
+  "CST6CDT": "america_chicago",
+  "EET": "europe_sofia",
+  "EST": "america_cancun",
+  "EST5EDT": "america_new_york",
+  "GB": "europe_london",
+  "GB-Eire": "europe_london",
+  "HST": "pacific_honolulu",
+  "MET": "europe_paris",
+  "MST": "america_phoenix",
+  "MST7MDT": "america_denver",
+  "PST8PDT": "america_los_angeles",
+  "WET": "europe_lisbon"
 }


### PR DESCRIPTION
macOS since version 14 reports "CET" as time zone instead of "Europe/Berlin". This isn't contained in tzdb.json, so time_machine fails to perform the time zone lookup during initialization. This patch adds a couple of aliases to tzdb.json.